### PR TITLE
align on a single API for printing a model

### DIFF
--- a/docs/Causal.rst
+++ b/docs/Causal.rst
@@ -196,7 +196,7 @@ intervals. This example generates confidence intervals for ART exposure on death
   for i in range(500):
       dfs = df.sample(n=df.shape[0],replace=True)
       g = TimeFixedGFormula(dfs,exposure='art',outcome='dead')
-      g.outcome_model(model='art + male + age0 + age_rs1 + age_rs2 + cd40 + cd4_rs1 + cd4_rs2 + dvl0',print_model_results=False)
+      g.outcome_model(model='art + male + age0 + age_rs1 + age_rs2 + cd40 + cd4_rs1 + cd4_rs2 + dvl0',print_results=False)
       g.fit(treatment='all')
       r_all = g.marginal_outcome
       g.fit(treatment='none')
@@ -213,7 +213,7 @@ intervals. This example generates confidence intervals for ART exposure on death
   RD 95% CI: [-0.1588601  -0.02027014]
   RR 95% CI: [0.2659243  0.87927692]
 
-**NOTE** You will definitely want to use the ``print_model_results=False`` option in the ``outcome_model()``, otherwise
+**NOTE** You will definitely want to use the ``print_results=False`` option in the ``outcome_model()``, otherwise
 500 logistic regression results will be printed to your terminal. It is likely this will take at least several seconds
 to run, if not longer. Remember that it is fitting 500 logistic regression models to 500 bootstrapped sample to
 generate the confidence intervals.
@@ -402,7 +402,7 @@ estimates. Running ``sdr.summary()`` gives us the following results
 Confidence Intervals
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 As recommended, confidence intervals should be obtained from a non-parametric bootstrap. As will other methods, it is
-important to specify ``print_model_results=False`` in the model statements. Otherwise, each fit model of the bootstrap
+important to specify ``print_results=False`` in the model statements. Otherwise, each fit model of the bootstrap
 will be printed to the terminal. The bootstrap can be implemented by the following the general structure of the below
 code
 
@@ -413,7 +413,7 @@ code
   for i in range(500):
       dfs = df.sample(n=df.shape[0],replace=True)
       s = AIPW(dfs,exposure='art',outcome='dead')
-      s.exposure_model('male + age0 + age_rs1 + age_rs2 + cd40 + cd4_rs1 + cd4_rs2 + dvl0',print_model_results=False)
+      s.exposure_model('male + age0 + age_rs1 + age_rs2 + cd40 + cd4_rs1 + cd4_rs2 + dvl0',print_results=False)
       s.outcome_model('art + male + age0 + age_rs1 + age_rs2 + cd40 + cd4_rs1 + cd4_rs2 + dvl0',print_model_result=False)
       s.fit()
       rd.append(s.riskdiff)
@@ -459,9 +459,9 @@ Inverse Probability Weight fitting procedure.
 .. code:: python
 
   tm.exposure_model('male + age0 + age_rs1 + age_rs2 + cd40 + cd4_rs1 + cd4_rs2 + dvl0',
-                    print_model_results=False)
+                    print_results=False)
   tm.outcome_model('art + male + age0 + age_rs1 + age_rs2 + cd40 + cd4_rs1 + cd4_rs2 + dvl0',
-                   print_model_results=False)
+                   print_results=False)
 
 After both models are specified the TMLE model can be fit. Results can be printed to the console via ``TMLE.summary()``
 

--- a/docs/causal_comparisons.py
+++ b/docs/causal_comparisons.py
@@ -1,10 +1,10 @@
 import numpy as np
-import statsmodels.api as sm 
-import statsmodels.formula.api as smf 
+import statsmodels.api as sm
+import statsmodels.formula.api as smf
 from statsmodels.genmod.families import family,links
-import matplotlib.pyplot as plt 
+import matplotlib.pyplot as plt
 
-import zepid as ze 
+import zepid as ze
 from zepid.causal.gformula import TimeFixedGFormula
 from zepid.causal.doublyrobust import SimpleDoubleRobust
 
@@ -17,10 +17,10 @@ ze.RiskRatio(df,exposure='art',outcome='dead')
 ze.RiskDiff(df,exposure='art',outcome='dead')
 #Adjusted Model
 model = 'art + male + age0 + cd40 + dvl0'
-f = sm.families.family.Binomial(sm.families.links.identity) 
+f = sm.families.family.Binomial(sm.families.links.identity)
 linrisk = smf.glm('dead ~ '+model,df,family=f).fit()
 linrisk.summary()
-f = sm.families.family.Binomial(sm.families.links.log) 
+f = sm.families.family.Binomial(sm.families.links.log)
 log = smf.glm('dead ~ art',df,family=f).fit()
 log.summary()
 #g-formula
@@ -37,7 +37,7 @@ rr_results = []
 for i in range(500):
     dfs = df.sample(n=df.shape[0],replace=True)
     g = TimeFixedGFormula(dfs,exposure='art',outcome='dead')
-    g.outcome_model(model='art + male + age0 + age_rs1 + age_rs2 + cd40 + cd4_rs1 + cd4_rs2 + dvl0',print_model_results=False)
+    g.outcome_model(model='art + male + age0 + age_rs1 + age_rs2 + cd40 + cd4_rs1 + cd4_rs2 + dvl0', print_results=False)
     g.fit(treatment='all')
     r_all = g.marginal_outcome
     g.fit(treatment='none')
@@ -48,14 +48,14 @@ for i in range(500):
 
 print('RD 95% CI:',np.percentile(rd_results,q=[2.5,97.5]))
 print('RR 95% CI:',np.percentile(rr_results,q=[2.5,97.5]))
-#IPTW 
+#IPTW
 model = 'male + age0 + age_rs1 + age_rs2 + cd40 + cd4_rs1 + cd4_rs2 + dvl0'
 df['iptw'] = ze.ipw.iptw(df,treatment='art',model_denominator=model,stabilized=True)
 ind = sm.cov_struct.Independence()
-f = sm.families.family.Binomial(sm.families.links.identity) 
+f = sm.families.family.Binomial(sm.families.links.identity)
 linrisk = smf.gee('dead ~ art',df['id'],df,cov_struct=ind,family=f,weights=df['iptw']).fit()
 linrisk.summary()
-f = sm.families.family.Binomial(sm.families.links.log) 
+f = sm.families.family.Binomial(sm.families.links.log)
 log = smf.gee('dead ~ art',df['id'],df,cov_struct=ind,family=f,weights=df['iptw']).fit()
 log.summary()
 #Double-Robust
@@ -69,8 +69,8 @@ rr = []
 for i in range(500):
     dfs = df.sample(n=df.shape[0],replace=True)
     s = SimpleDoubleRobust(dfs,exposure='art',outcome='dead')
-    s.exposure_model('male + age0 + age_rs1 + age_rs2 + cd40 + cd4_rs1 + cd4_rs2 + dvl0',print_model_results=False)
-    s.outcome_model('art + male + age0 + age_rs1 + age_rs2 + cd40 + cd4_rs1 + cd4_rs2 + dvl0',print_model_results=False)
+    s.exposure_model('male + age0 + age_rs1 + age_rs2 + cd40 + cd4_rs1 + cd4_rs2 + dvl0', print_results=False)
+    s.outcome_model('art + male + age0 + age_rs1 + age_rs2 + cd40 + cd4_rs1 + cd4_rs2 + dvl0', print_results=False)
     s.fit()
     rd.append(s.riskdiff)
     rr.append(s.riskratio)

--- a/zepid/causal/doublyrobust/AIPW.py
+++ b/zepid/causal/doublyrobust/AIPW.py
@@ -32,33 +32,33 @@ class AIPW:
         self._exp_model = None
         self._out_model = None
 
-    def exposure_model(self, model, print_model_results=True):
+    def exposure_model(self, model, print_results=True):
         """Used to specify the propensity score model. Model used to predict the exposure via a logistic regression
         model
 
         model:
             -Independent variables to predict the exposure. Example) 'var1 + var2 + var3'
-        print_model_results:
+        print_results:
             -Whether to print the fitted model results. Default is True (prints results)
         """
         self._exp_model = self._exposure + ' ~ ' + model
-        fitmodel = propensity_score(self.df, self._exp_model, mresult=print_model_results)
+        fitmodel = propensity_score(self.df, self._exp_model, print_results=print_results)
         self.df['ps'] = fitmodel.predict(self.df)
         self._fit_exposure_model = True
 
-    def outcome_model(self, model, print_model_results=True):
+    def outcome_model(self, model, print_results=True):
         """Used to specify the outcome model. Model used to predict the outcome via a logistic regression model
 
         model:
             -Independent variables to predict the outcome. Example) 'var1 + var2 + var3 + var4'
-        print_model_results:
+        print_results:
             -Whether to print the fitted model results. Default is True (prints results)
         """
 
         self._out_model = self._outcome + ' ~ ' + model
         f = sm.families.family.Binomial(sm.families.links.logit)
         log = smf.glm(self._out_model, self.df, family=f).fit()
-        if print_model_results:
+        if print_results:
             print('\n----------------------------------------------------------------')
             print('MODEL: ' + self._out_model)
             print('-----------------------------------------------------------------')

--- a/zepid/causal/doublyrobust/TMLE.py
+++ b/zepid/causal/doublyrobust/TMLE.py
@@ -57,32 +57,32 @@ class TMLE:
         self.psi = None
         self.confint = None
 
-    def exposure_model(self, model, print_model_results=True):
+    def exposure_model(self, model, print_results=True):
         """Estimation of g(A=1,W), which is Pr(A=1|W)
 
         model:
             -Independent variables to predict the exposure. Example) 'var1 + var2 + var3'
-        print_model_results:
+        print_results:
             -Whether to print the fitted model results. Default is True (prints results)
         """
         self._exp_model = self._exposure + ' ~ ' + model
-        fitmodel = propensity_score(self.df, self._exp_model, mresult=print_model_results)
+        fitmodel = propensity_score(self.df, self._exp_model, print_results=print_results)
         self.gA1 = fitmodel.predict(self.df)
         self._fit_exposure_model = True
 
-    def outcome_model(self, model, print_model_results=True):
+    def outcome_model(self, model, print_results=True):
         """Estimation of Q(A,W), which is Pr(Y=1|A,W)
 
         model:
             -Independent variables to predict the exposure. Example) 'var1 + var2 + var3'
-        print_model_results:
+        print_results:
             -Whether to print the fitted model results. Default is True (prints results)
         """
         self._out_model = self._outcome + ' ~ ' + model
         f = sm.families.family.Binomial(sm.families.links.logit)
         log = smf.glm(self._out_model, self.df, family=f).fit()
 
-        if print_model_results:
+        if print_results:
             print('\n----------------------------------------------------------------')
             print('MODEL: ' + self._out_model)
             print('-----------------------------------------------------------------')

--- a/zepid/causal/ipw/IPCW.py
+++ b/zepid/causal/ipw/IPCW.py
@@ -53,7 +53,7 @@ class IPCW:
         self.event = event
         self.Weight = None
 
-    def regression_models(self, model_denominator, model_numerator, print_model_results=True):
+    def regression_models(self, model_denominator, model_numerator, print_results=True):
         """
 
         model_denominator:
@@ -63,12 +63,12 @@ class IPCW:
         model_numerator:
             -statsmodels glm format for modeling data. Only includes predictor variables for the numerator. In general,
              time is included in the numerator. Example) 't_start + t_squared'
-        print_model_results:
+        print_results:
             -whether to print the model results. Default is True
         """
-        nmodel = propensity_score(self.df, 'uncensored ~ ' + model_numerator, mresult=print_model_results)
+        nmodel = propensity_score(self.df, 'uncensored ~ ' + model_numerator, print_results=print_results)
         self.df['numer'] = nmodel.predict(self.df)
-        dmodel = propensity_score(self.df, 'uncensored ~ ' + model_denominator, mresult=print_model_results)
+        dmodel = propensity_score(self.df, 'uncensored ~ ' + model_denominator, print_results=print_results)
         self.df['denom'] = dmodel.predict(self.df)
         self.df['cnumer'] = self.df.groupby(self.idvar)['numer'].cumprod()
         self.df['cdenom'] = self.df.groupby(self.idvar)['denom'].cumprod()

--- a/zepid/causal/ipw/IPMW.py
+++ b/zepid/causal/ipw/IPMW.py
@@ -35,7 +35,7 @@ class IPMW:
         self.stabilized = stabilized
         self.Weight = None
 
-    def fit(self, model, print_model_results=True):
+    def fit(self, model, print_results=True):
         """
         Provide the regression model to generate the inverse probability of missing weights. The fitted regression
         model will be used to generate the IPW. The weights can be accessed via the IMPW.Weight attribute
@@ -43,10 +43,10 @@ class IPMW:
         model:
             -statsmodels glm format for modeling data. Independent variables should be predictive of missingness of
              variable of interest. Example) 'var1 + var2 + var3'
-        print_model_results:
+        print_results:
             -whether to print the model results. Default is True
         """
-        mod = propensity_score(self.df, 'observed_indicator ~ ' + model, mresult=print_model_results)
+        mod = propensity_score(self.df, 'observed_indicator ~ ' + model, print_results=print_results)
         p = mod.predict(self.df)
         if self.stabilized:
             p_ = np.mean(self.df['observed_indicator'])

--- a/zepid/causal/ipw/IPTW.py
+++ b/zepid/causal/ipw/IPTW.py
@@ -38,7 +38,7 @@ class IPTW:
             raise ValueError('Please specify one of the currently supported weighting schemes: ' +
                              'population, exposed, unexposed')
 
-    def regression_models(self, model_denominator, model_numerator='1', print_model_results=True):
+    def regression_models(self, model_denominator, model_numerator='1', print_results=True):
         """
         Logistic regression model(s) for propensity score models. The model denominator must be specified for both
         stabilized and unstabilized weights. The optional argument 'model_numerator' allows specification of the
@@ -52,14 +52,14 @@ class IPTW:
              Default ('1') calculates the overall probability. In general this is recommended. If confounding
              variables are included in the numerator, they would later need to be adjusted for.
              Example) 'var1'
-        print_model_results:
+        print_results:
             -whether to print the model results from the regression models. Default is True
         """
         self.denominator_model = propensity_score(self.df, self.ex + ' ~ ' + model_denominator,
-                                                  mresult=print_model_results)
+                                                  print_results=print_results)
         if self.stabilized is True:
             self.numerator_model = propensity_score(self.df, self.ex + ' ~ ' + model_numerator,
-                                                    mresult=print_model_results)
+                                                    print_results=print_results)
         else:
             if model_numerator != '1':
                 warnings.warn('Argument for model_numerator is only used for stabilized=True')
@@ -151,7 +151,7 @@ class IPTW:
         sd = float(np.std(self.df['iptw'].dropna()))
         print('----------------------------------------------------------------------')
         print('IPW Diagnostic for positivity')
-        print('''If the mean of the weights is far from either the min or max, this may\n indicate the model is 
+        print('''If the mean of the weights is far from either the min or max, this may\n indicate the model is
                 incorrect or positivity is violated''')
         print('Standard deviation can help in IPTW model selection')
         print('----------------------------------------------------------------------')

--- a/zepid/causal/ipw/utils.py
+++ b/zepid/causal/ipw/utils.py
@@ -4,7 +4,7 @@ import statsmodels.api as sm
 import statsmodels.formula.api as smf
 from statsmodels.genmod.families import links
 
-def propensity_score(df, model, mresult=True):
+def propensity_score(df, model, print_results=True):
     '''Generate propensity scores (probability) based on the model input. Uses logistic regression model
     to calculate
 
@@ -14,7 +14,7 @@ def propensity_score(df, model, mresult=True):
         -Dataframe for the model
     model:
         -Model to fit the logistic regression to. Example) 'y ~ var1 + var2'
-    mresult:
+    print_results:
         -Whether to print the logistic regression results. Default is True
 
     Example)
@@ -22,7 +22,7 @@ def propensity_score(df, model, mresult=True):
     '''
     f = sm.families.family.Binomial(sm.families.links.logit)
     log = smf.glm(model, df, family=f).fit()
-    if mresult == True:
+    if print_results == True:
         print('\n----------------------------------------------------------------')
         print('MODEL: ' + model)
         print('-----------------------------------------------------------------')


### PR DESCRIPTION
Some small changes to the API for printing models: previously there were three different signatures, this fixes it to a single `print_results` (which is short and clear imo). 

