### PR TITLE
Support Prediction from PyGAM LogisticGAM

### DIFF
--- a/zepid/causal/utils.py
+++ b/zepid/causal/utils.py
@@ -68,8 +68,12 @@ def exposure_machine_learner(xdata, ydata, ml_model, print_results=True):
 
     # Generating predictions
     if hasattr(fm, 'predict_proba'):
-        g = fm.predict_proba(xdata)[:, 1]
-        return g
+        g = fm.predict_proba(xdata)
+        # this allows support for pygam LogisticGAM, which only returns only 1 probability
+        if g.ndim == 1:
+            return g
+        else:
+            return g[:, 1]
     elif hasattr(fm, 'predict'):
         g = fm.predict(xdata)
         return g

--- a/zepid/causal/utils.py
+++ b/zepid/causal/utils.py
@@ -107,9 +107,12 @@ def outcome_machine_learner(xdata, ydata, all_a, none_a, ml_model, continuous, p
 
     else:
         if hasattr(fm, 'predict_proba'):
-            qa1 = fm.predict_proba(all_a)[:, 1]
-            qa0 = fm.predict_proba(none_a)[:, 1]
-            return qa1, qa0
+            qa1 = fm.predict_proba(all_a)
+            qa0 = fm.predict_proba(none_a)
+            if (qa1.ndim == 1) and (qa0.ndim == 1):
+                return qa1, qa0
+            else:
+                return qa1[:,1], qa0[:,1]
         elif hasattr(fm, 'predict'):
             qa1 = fm.predict(all_a)
             qa0 = fm.predict(none_a)
@@ -135,9 +138,12 @@ def missing_machine_learner(xdata, mdata, all_a, none_a, ml_model, print_results
 
     # Generating predictions
     if hasattr(fm, 'predict_proba'):
-        ma1 = fm.predict_proba(all_a)[:, 1]
-        ma0 = fm.predict_proba(none_a)[:, 1]
-        return ma1, ma0
+        ma1 = fm.predict_proba(all_a)
+        ma0 = fm.predict_proba(none_a)
+        if (ma1.ndim == 1) and (ma0.ndim == 1):
+            return ma1, ma0
+        else:
+            return ma1[:, 1], ma0[:, 1]
     elif hasattr(fm, 'predict'):
         ma1 = fm.predict(all_a)
         ma0 = fm.predict(none_a)


### PR DESCRIPTION
PyGAM returns one set of probabilities unlike sklearn which returns 2. The automatic [:,1] in associated with the output of the exposure_machine_learner prevents using LogisticGAM. Other than that, they can integrate seamlessly since it largely follows the sklearn style. I added a simple check of the dimensions of the ndarray which either indexes into the array in the case of more than 1 dimension or directly returns the array when there is only one dimension. It's a pretty simple change but allows us to use a super powerful library.